### PR TITLE
48433 - [typing] String literal splitting should use formatter preferences 

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaStringAutoIndentStrategy.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaStringAutoIndentStrategy.java
@@ -208,8 +208,19 @@ public class JavaStringAutoIndentStrategy extends DefaultIndentLineAutoEditStrat
 	 * @return two tabs or equivalent number of spaces
 	 */
 	private String getExtraIndentAfterNewLine() {
-		int formatterTabSizePref= CodeFormatterUtil.getTabWidth(fProject);
-		return CodeFormatterUtil.createIndentString(formatterTabSizePref, fProject);
+		// read settings
+		int formatterContinuationIndentationSize= 2;
+		try
+		{
+			formatterContinuationIndentationSize = Integer.parseInt(getCoreFormatterOption(DefaultCodeFormatterConstants.FORMATTER_CONTINUATION_INDENTATION));
+		}
+		catch (NumberFormatException ex)
+		{
+			// Ignore, use default of 2
+		}
+		
+		// generate indentation string with correct size
+		return CodeFormatterUtil.createIndentString(formatterContinuationIndentationSize, fProject);
 	}
 
 	private boolean isSmartMode() {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaStringAutoIndentStrategy.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaStringAutoIndentStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010, 2011, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2012 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,11 +7,8 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
- *     Kelly Campbell <kellyc@google.com> - [typing] String literal splitting
- *       should use formatter preferences - http://bugs.eclipse.org/48433
- *     Martin Hare Robertson <mchr3k@gmail.com> - [typing] String literal
- *       splitting should use formatter preferences -
- *       http://bugs.eclipse.org/48433
+ *     Kelly Campbell <kellyc@google.com> - [typing] String literal splitting should use formatter preferences - http://bugs.eclipse.org/48433
+ *     Martin Hare Robertson <mchr3k@gmail.com> - [typing] String literal splitting should use formatter preferences - http://bugs.eclipse.org/48433
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.text.java;
 
@@ -181,26 +178,57 @@ public class JavaStringAutoIndentStrategy extends DefaultIndentLineAutoEditStrat
 		String string= document.get(line.getOffset(), offset - line.getOffset()).trim();
 		if (string.length() != 0 && !string.equals("+")) //$NON-NLS-1$
 			indentation += getExtraIndentAfterNewLine();
-
-		IPreferenceStore preferenceStore= JavaPlugin.getDefault().getPreferenceStore();
+		
 		boolean isLineDelimiter= isLineDelimiter(document, command.text);
-		if (preferenceStore.getBoolean(PreferenceConstants.EDITOR_WRAP_STRINGS) && isLineDelimiter) {
-			if (DefaultCodeFormatterConstants.TRUE.equals(getCoreFormatterOption(DefaultCodeFormatterConstants.FORMATTER_WRAP_BEFORE_BINARY_OPERATOR))) {
+		if (isEditorWrapStrings() && isLineDelimiter) {
+			if (isWrappingBeforeBinaryOperator()) {
 				command.text= "\"" + command.text + indentation + "+ \"";  //$NON-NLS-1$//$NON-NLS-2$
 			} else {
 				command.text= "\" +" + command.text + indentation + "\"";  //$NON-NLS-1$//$NON-NLS-2$
 			}
-		} else if (command.text.length() > 1 && !isLineDelimiter && preferenceStore.getBoolean(PreferenceConstants.EDITOR_ESCAPE_STRINGS)) {
+		} else if (command.text.length() > 1 && !isLineDelimiter && isEditorEscapeStrings()) {
 			command.text= getModifiedText(command.text, indentation, delimiter);
 		}
 	}
-
+	
+	private boolean isEditorWrapStrings() {
+		IPreferenceStore preferenceStore= JavaPlugin.getDefault().getPreferenceStore();
+		return preferenceStore.getBoolean(PreferenceConstants.EDITOR_WRAP_STRINGS);
+	}
+	
+	private boolean isEditorEscapeStrings() {
+		IPreferenceStore preferenceStore= JavaPlugin.getDefault().getPreferenceStore();
+		return preferenceStore.getBoolean(PreferenceConstants.EDITOR_ESCAPE_STRINGS);
+	}
+	
 	private String getCoreFormatterOption(String key) {
 		if (fProject == null)
 			return JavaCore.getOption(key);
 		return fProject.getOption(key, true);
 	}
+	
+	private boolean isWrappingBeforeBinaryOperator() {
+		return DefaultCodeFormatterConstants.TRUE.equals(getCoreFormatterOption(
+				DefaultCodeFormatterConstants.FORMATTER_WRAP_BEFORE_BINARY_OPERATOR));
+	}
 
+	private int getContinuationIndentationSize() {
+		int formatterContinuationIndentationSize= 2;
+		try {
+			formatterContinuationIndentationSize= Integer.parseInt(getCoreFormatterOption(
+					DefaultCodeFormatterConstants.FORMATTER_CONTINUATION_INDENTATION));
+		} catch (NumberFormatException ex) {
+			// Ignore, use default of 2
+		}
+		return formatterContinuationIndentationSize;
+	}
+	
+	private int getBinaryOperatorAlignmentStyle() {
+		String binaryAlignmentValue= getCoreFormatterOption(
+				DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_BINARY_EXPRESSION);
+		return DefaultCodeFormatterConstants.getIndentStyle(binaryAlignmentValue);
+	}
+	
 	/**
 	 * Returns extra indentation string for strings that are broken by a newline
 	 * based on the value of the formatter preferences for tabs vs. spaces.
@@ -209,18 +237,19 @@ public class JavaStringAutoIndentStrategy extends DefaultIndentLineAutoEditStrat
 	 */
 	private String getExtraIndentAfterNewLine() {
 		// read settings
-		int formatterContinuationIndentationSize= 2;
-		try
-		{
-			formatterContinuationIndentationSize = Integer.parseInt(getCoreFormatterOption(DefaultCodeFormatterConstants.FORMATTER_CONTINUATION_INDENTATION));
-		}
-		catch (NumberFormatException ex)
-		{
-			// Ignore, use default of 2
+		int formatterContinuationIndentationSize= getContinuationIndentationSize();
+		int binaryAlignmentValue= getBinaryOperatorAlignmentStyle();
+		
+		// work out indent
+		int indentSize= formatterContinuationIndentationSize;
+		if (binaryAlignmentValue == DefaultCodeFormatterConstants.INDENT_BY_ONE) {
+			indentSize= 1;
+		} else if (binaryAlignmentValue == DefaultCodeFormatterConstants.INDENT_ON_COLUMN) {
+			// there is no obvious way to work out the current column indent
 		}
 		
 		// generate indentation string with correct size
-		return CodeFormatterUtil.createIndentString(formatterContinuationIndentationSize, fProject);
+		return CodeFormatterUtil.createIndentString(indentSize, fProject);
 	}
 
 	private boolean isSmartMode() {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/JavaSourceViewerConfiguration.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/JavaSourceViewerConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2010, 2012 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,6 +8,11 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Tom Eicher (Avaloq Evolution AG) - block selection mode
+ *     Kelly Campbell <kellyc@google.com> - [typing] String literal splitting
+ *       should use formatter preferences - http://bugs.eclipse.org/48433
+ *     Martin Hare Robertson <mchr3k@gmail.com> - [typing] String literal
+ *       splitting should use formatter preferences -
+ *       http://bugs.eclipse.org/48433
  *******************************************************************************/
 package org.eclipse.jdt.ui.text;
 
@@ -467,7 +472,7 @@ public class JavaSourceViewerConfiguration extends TextSourceViewerConfiguration
 		if (IJavaPartitions.JAVA_DOC.equals(contentType) || IJavaPartitions.JAVA_MULTI_LINE_COMMENT.equals(contentType))
 			return new IAutoEditStrategy[] { new JavaDocAutoIndentStrategy(partitioning) };
 		else if (IJavaPartitions.JAVA_STRING.equals(contentType))
-			return new IAutoEditStrategy[] { new SmartSemicolonAutoEditStrategy(partitioning), new JavaStringAutoIndentStrategy(partitioning) };
+			return new IAutoEditStrategy[] { new SmartSemicolonAutoEditStrategy(partitioning), new JavaStringAutoIndentStrategy(partitioning, getProject()) };
 		else if (IJavaPartitions.JAVA_CHARACTER.equals(contentType) || IDocument.DEFAULT_CONTENT_TYPE.equals(contentType))
 			return new IAutoEditStrategy[] { new SmartSemicolonAutoEditStrategy(partitioning), new JavaAutoIndentStrategy(partitioning, getProject(), sourceViewer) };
 		else

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/JavaSourceViewerConfiguration.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/JavaSourceViewerConfiguration.java
@@ -8,11 +8,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Tom Eicher (Avaloq Evolution AG) - block selection mode
- *     Kelly Campbell <kellyc@google.com> - [typing] String literal splitting
- *       should use formatter preferences - http://bugs.eclipse.org/48433
- *     Martin Hare Robertson <mchr3k@gmail.com> - [typing] String literal
- *       splitting should use formatter preferences -
- *       http://bugs.eclipse.org/48433
+ *     Kelly Campbell <kellyc@google.com> - [typing] String literal splitting should use formatter preferences - http://bugs.eclipse.org/48433
+ *     Martin Hare Robertson <mchr3k@gmail.com> - [typing] String literal splitting should use formatter preferences - http://bugs.eclipse.org/48433
  *******************************************************************************/
 package org.eclipse.jdt.ui.text;
 


### PR DESCRIPTION
Fix for bug 48433 (https://bugs.eclipse.org/bugs/show_bug.cgi?id=48433)

Full details are available on the bugzilla page.
